### PR TITLE
feat: Do not define T4TemplateBase on T4CodeWriter

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>Recommended</AnalysisMode>
-    <NBGV_EmitThisAssemblyClass>false</NBGV_EmitThisAssemblyClass>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,7 +7,6 @@
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.25" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.112" />
-    <PackageVersion Include="Polyfill" Version="7.8.0" />
     <PackageVersion Include="System.Memory" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/src/T4CodeWriter.Sources/T4CodeWriter.Sources.csproj
+++ b/src/T4CodeWriter.Sources/T4CodeWriter.Sources.csproj
@@ -6,6 +6,7 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <NBGV_EmitThisAssemblyClass>false</NBGV_EmitThisAssemblyClass>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/T4CodeWriter.Sources/T4CodeWriter.Sources.csproj
+++ b/src/T4CodeWriter.Sources/T4CodeWriter.Sources.csproj
@@ -5,6 +5,7 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/T4CodeWriter/CodeWriterBase.cs
+++ b/src/T4CodeWriter/CodeWriterBase.cs
@@ -7,14 +7,13 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
-using Raiqub.T4Template;
 
 namespace Raiqub.Generators.T4CodeWriter
 {
     /// <summary>Represents the base class for code writers.</summary>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.Generators.T4CodeWriter", "1.0.0.0")]
-    public abstract class CodeWriterBase : T4TemplateBase
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.Generators.T4CodeWriter", "1.1.0.0")]
+    public abstract partial class CodeWriterBase
     {
         /// <summary>
         /// Initializes a new instance of the CodeWriterBase class with a StringBuilder.
@@ -22,17 +21,17 @@ namespace Raiqub.Generators.T4CodeWriter
         /// <param name="builder">The StringBuilder object used for building the template.</param>
         /// <param name="charsPerIndentation">The number of characters per indentation level.</param>
         protected CodeWriterBase(StringBuilder builder, int charsPerIndentation = CharsPerIndentation)
-            : base(builder, charsPerIndentation)
         {
+            _builder = builder;
+            _charsPerIndentation = charsPerIndentation;
         }
+
+        /// <summary>Gets the name of the current assembly.</summary>
+        protected static AssemblyName CurrentAssemblyName { get; } = typeof(CodeWriterBase).Assembly.GetName();
 
         /// <summary>Retrieves the name of the file for the code of current code writer state.</summary>
         /// <returns>The name of the file.</returns>
         public abstract string GetFileName();
-
-        /// <summary>Create the source text from current code writer state.</summary>
-        /// <returns>The transformed text.</returns>
-        public abstract override string TransformText();
 
         /// <summary>Adds a source to the compilation using the provided context.</summary>
         /// <param name="context">The source production context.</param>

--- a/src/T4CodeWriter/CodeWriterBase.cs
+++ b/src/T4CodeWriter/CodeWriterBase.cs
@@ -12,7 +12,7 @@ namespace Raiqub.Generators.T4CodeWriter
 {
     /// <summary>Represents the base class for code writers.</summary>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.Generators.T4CodeWriter", "1.1.0.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.Generators.T4CodeWriter", GeneratorInfo.Version)]
     public abstract partial class CodeWriterBase
     {
         /// <summary>

--- a/src/T4CodeWriter/CodeWriterBase{T}.cs
+++ b/src/T4CodeWriter/CodeWriterBase{T}.cs
@@ -9,7 +9,7 @@ namespace Raiqub.Generators.T4CodeWriter
     /// <summary>Base class for code writers that generate compilation source.</summary>
     /// <typeparam name="T">The type of the model associated with the code writer.</typeparam>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.Generators.T4CodeWriter", "1.0.0.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.Generators.T4CodeWriter", GeneratorInfo.Version)]
     public abstract class CodeWriterBase<T> : CodeWriterBase
     {
         /// <summary>

--- a/src/T4CodeWriter/CodeWriterDispatcher.cs
+++ b/src/T4CodeWriter/CodeWriterDispatcher.cs
@@ -9,7 +9,7 @@ namespace Raiqub.Generators.T4CodeWriter
 {
     /// <summary>Represents a dispatcher for code writers that generate compilation source.</summary>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.Generators.T4CodeWriter", "1.0.0.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.Generators.T4CodeWriter", GeneratorInfo.Version)]
     public sealed class CodeWriterDispatcher
     {
         private const int DefaultStringBuilderCapacity = 1024;

--- a/src/T4CodeWriter/CodeWriterDispatcher{T}.cs
+++ b/src/T4CodeWriter/CodeWriterDispatcher{T}.cs
@@ -11,7 +11,7 @@ namespace Raiqub.Generators.T4CodeWriter
     /// <summary>Represents a dispatcher for code writers that generate compilation source.</summary>
     /// <typeparam name="T">The type associated with the code writer.</typeparam>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.Generators.T4CodeWriter", "1.0.0.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.Generators.T4CodeWriter", GeneratorInfo.Version)]
     public sealed class CodeWriterDispatcher<T>
     {
         private const int DefaultStringBuilderCapacity = 1024;

--- a/src/T4CodeWriter/GeneratorInfo.cs
+++ b/src/T4CodeWriter/GeneratorInfo.cs
@@ -1,0 +1,10 @@
+﻿namespace Raiqub.Generators.T4CodeWriter;
+
+internal static class GeneratorInfo
+{
+#if IS_COMPILED
+    internal const string Version = ThisAssembly.AssemblyFileVersion;
+#else
+    internal const string Version = "1.1.0.0";
+#endif
+}

--- a/src/T4CodeWriter/T4CodeWriter.csproj
+++ b/src/T4CodeWriter/T4CodeWriter.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <DefineConstants>$(DefineConstants);IS_COMPILED</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/T4Template/T4Template.csproj
+++ b/src/T4Template/T4Template.csproj
@@ -5,6 +5,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RootNamespace>Raiqub.$(MSBuildProjectName)</RootNamespace>
     <AssemblyName>$(RootNamespace)</AssemblyName>
+    <DefineConstants>$(DefineConstants);IS_T4_TEMPLATE_BASE</DefineConstants>
   </PropertyGroup>
 
   <Import

--- a/src/T4Template/T4TemplateBase.cs
+++ b/src/T4Template/T4TemplateBase.cs
@@ -6,12 +6,18 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 
+#if IS_T4_TEMPLATE_BASE
 namespace Raiqub.T4Template
 {
     /// <summary>Represents the base class for T4 templates.</summary>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.T4Template", "1.0.0.0")]
-    public abstract class T4TemplateBase
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.T4Template", "1.1.0.0")]
+    public abstract partial class T4TemplateBase
+#else
+namespace Raiqub.Generators.T4CodeWriter
+{
+    public abstract partial class CodeWriterBase
+#endif
     {
         private const char IndentationChar = ' ';
 
@@ -22,6 +28,7 @@ namespace Raiqub.T4Template
         private readonly int _charsPerIndentation;
         private int _indentation;
 
+#if IS_T4_TEMPLATE_BASE
         /// <summary>
         /// Initializes a new instance of the T4TemplateBase class.
         /// </summary>
@@ -42,9 +49,7 @@ namespace Raiqub.T4Template
             _builder = builder;
             _charsPerIndentation = charsPerIndentation;
         }
-
-        /// <summary>Gets the name of the current assembly.</summary>
-        protected static AssemblyName CurrentAssemblyName { get; } = typeof(T4TemplateBase).Assembly.GetName();
+#endif
 
         /// <summary>Gets or sets the string builder that generation-time code is using to assemble generated output.</summary>
         protected StringBuilder GenerationEnvironment => _builder;
@@ -1131,9 +1136,15 @@ namespace Raiqub.T4Template
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public object? ToStringWithCulture(object? value) => value;
 
+#if IS_T4_TEMPLATE_BASE
             /// <summary>Does nothing, used by <see cref="T4TemplateBase.Append(string?)"/> method.</summary>
             /// <param name="none">An empty value.</param>
             /// <returns>The <paramref name="none"/> without any change.</returns>
+#else
+            /// <summary>Does nothing, used by <see cref="CodeWriterBase.Append(string?)"/> method.</summary>
+            /// <param name="none">An empty value.</param>
+            /// <returns>The <paramref name="none"/> without any change.</returns>
+#endif
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public None ToStringWithCulture(None none)
             {
@@ -1146,7 +1157,11 @@ namespace Raiqub.T4Template
         [InterpolatedStringHandler]
         protected readonly struct WriteInterpolatedStringHandler
         {
+#if IS_T4_TEMPLATE_BASE
             private readonly T4TemplateBase _templateBase;
+#else
+            private readonly CodeWriterBase _templateBase;
+#endif
 
             /// <summary>
             /// Initializes a new instance of the <see cref="WriteInterpolatedStringHandler"/> struct.
@@ -1154,7 +1169,11 @@ namespace Raiqub.T4Template
             /// <param name="literalLength">The length of the literal part of the interpolated string.</param>
             /// <param name="formattedCount">The number of formatted expressions in the interpolated string.</param>
             /// <param name="templateBase">The T4 template to append the formatted string to.</param>
+#if IS_T4_TEMPLATE_BASE
             public WriteInterpolatedStringHandler(int literalLength, int formattedCount, T4TemplateBase templateBase)
+#else
+            public WriteInterpolatedStringHandler(int literalLength, int formattedCount, CodeWriterBase templateBase)
+#endif
             {
                 _templateBase = templateBase;
             }

--- a/src/T4Template/T4TemplateBase.cs
+++ b/src/T4Template/T4TemplateBase.cs
@@ -11,7 +11,7 @@ namespace Raiqub.T4Template
 {
     /// <summary>Represents the base class for T4 templates.</summary>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.T4Template", "1.1.0.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.T4Template", ThisAssembly.AssemblyFileVersion)]
     public abstract partial class T4TemplateBase
 #else
 namespace Raiqub.Generators.T4CodeWriter

--- a/src/T4Template/T4TemplateBase{T}.cs
+++ b/src/T4Template/T4TemplateBase{T}.cs
@@ -8,7 +8,7 @@ namespace Raiqub.T4Template
     /// <summary>Base class for T4 templates.</summary>
     /// <typeparam name="T">The type of the model associated with the template.</typeparam>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.T4Template", "1.0.0.0")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.T4Template", ThisAssembly.AssemblyFileVersion)]
     public abstract class T4TemplateBase<T> : T4TemplateBase
     {
         /// <summary>


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub T4 Code Writer!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- Useless T4TemplateBase base class for T4CodeWriter

## Details on the issue fix or feature implementation
- Redesign T4TemplateBase as a part of T4CodeWriter when available

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
