### PR TITLE
fix: Allow minimum version match for System.Memory

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,13 @@
     "local>skarllot/renovate-config"
   ],
   "reviewers": ["skarllot"],
-  "assignees": ["skarllot"]
+  "assignees": ["skarllot"],
+  "packageRules": [
+    {
+      "description": "Pin System.Memory",
+      "matchDatasources": ["nuget"],
+      "matchPackageNames": ["System.Memory"],
+      "enabled": false
+    }
+  ]
 }

--- a/src/T4Template/T4Template.csproj
+++ b/src/T4Template/T4Template.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Memory" Version="[4.5.4]" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <Import

--- a/src/T4Template/packages.lock.json
+++ b/src/T4Template/packages.lock.json
@@ -25,7 +25,7 @@
       },
       "System.Memory": {
         "type": "Direct",
-        "requested": "[4.5.4, 4.5.4]",
+        "requested": "[4.5.4, )",
         "resolved": "4.5.4",
         "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
         "dependencies": {


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub T4 Code Writer!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

- T4Template package enforces exact System.Memory match

## Details on the issue fix or feature implementation

- Change to minimum version match for System.Memory
- Disable automatic update of System.Memory package

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
