### PR TITLE
ci(github-action): switch harden-runner to block mode with explicit endpoint allowlists

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,23 @@ jobs:
     - name: 🛡️ Harden Runner
       uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
       with:
-        egress-policy: audit
+        egress-policy: block
+        disable-sudo-and-containers: true
+        allowed-endpoints: >
+          *.azureedge.net:443
+          *.digicert.com:80
+          *.github.com:443
+          *.githubusercontent.com:443
+          *.ws.symantec.com:80
+          aka.ms:443
+          api.nuget.org:443
+          builds.dotnet.microsoft.com:443
+          ci.dot.net:443
+          dc.services.visualstudio.com:443
+          github.com:443
+          s.symcb.com:80
+          s.symcd.com:80
+          www.microsoft.com:80
 
     - name: 🛒 Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -22,7 +22,15 @@ jobs:
     - name: 🛡️ Harden Runner
       uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
       with:
-        egress-policy: audit
+        egress-policy: block
+        disable-sudo-and-containers: true
+        allowed-endpoints: >
+          *.azureedge.net:443
+          aka.ms:443
+          api.nuget.org:443
+          builds.dotnet.microsoft.com:443
+          ci.dot.net:443
+          github.com:443
 
     - name: 🛒 Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,7 +19,13 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          disable-sudo-and-containers: true
+          allowed-endpoints: >
+            api.deps.dev:443
+            api.github.com:443
+            api.securityscorecards.dev:443
+            github.com:443
 
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,7 +26,27 @@ jobs:
     - name: 🛡️ Harden Runner
       uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
       with:
-        egress-policy: audit
+        egress-policy: block
+        disable-sudo-and-containers: true
+        allowed-endpoints: >
+          *.azureedge.net:443
+          *.codecov.io:443
+          *.digicert.com:80
+          *.github.com:443
+          *.ws.symantec.com:80
+          aka.ms:443
+          api.nuget.org:443
+          builds.dotnet.microsoft.com:443
+          ci.dot.net:443
+          codecov.io:443
+          dc.services.visualstudio.com:443
+          github.com:443
+          keybase.io:443
+          o26192.ingest.us.sentry.io:443
+          s.symcb.com:80
+          s.symcd.com:80
+          storage.googleapis.com:443
+          www.microsoft.com:80
 
     - name: 🛒 Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,7 +21,21 @@ jobs:
       - name: 🛡️ Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          disable-sudo-and-containers: true
+          allowed-endpoints: >
+            *.azureedge.net:443
+            *.digicert.com:80
+            *.nuget.org:443
+            *.ws.symantec.com:80
+            aka.ms:443
+            builds.dotnet.microsoft.com:443
+            ci.dot.net:443
+            dc.services.visualstudio.com:443
+            github.com:443
+            s.symcb.com:80
+            s.symcd.com:80
+            www.microsoft.com:80
 
       - name: 🛒 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,7 +34,19 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            *.github.com:443
+            *.sigstore.dev:443
+            api.deps.dev:443
+            api.github.com:443
+            api.osv.dev:443
+            api.scorecard.dev:443
+            api.securityscorecards.dev:443
+            github.com:443
+            oss-fuzz-build-logs.storage.googleapis.com:443
+            www.bestpractices.dev:443
 
       - name: "Checkout code"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

- Switches all 6 workflow `egress-policy` from `audit` to `block`, enforcing outbound network restrictions instead of just logging
- Adds `disable-sudo-and-containers: true` to all workflows (except `scorecard.yml` which uses `disable-sudo: true`)
- Adds explicit `allowed-endpoints` tailored to each workflow's actual dependencies

## Endpoint allowlists

| Workflow | Notable inclusions |
|---|---|
| `codeql.yml` | .NET SDK, NuGet, GitHub/CodeQL, cert validation CAs |
| `dotnet.yml` | Same + Codecov, Keybase, Sentry (`o26192`), GCS |
| `package.yml` | `*.nuget.org:443` wildcard covers both restore and push |
| `create-tag.yml` | Minimal: SDK download, NuGet (nbgv), GitHub |
| `dependency-review.yml` | `api.deps.dev`, `api.securityscorecards.dev`, GitHub |
| `scorecard.yml` | Scorecard APIs, sigstore, OSSF, `*.github.com` for sarif upload |

## Test plan

- [x] Open PR → verify `dependency-review` and `dotnet` workflows pass in block mode
- [x] Check Actions tab that harden-runner reports no unexpected blocked endpoints
- [ ] Merge to main → verify `codeql`, `scorecard`, and `dotnet` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to enforce stricter operational controls and restrict network access to essential services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->