### PR TITLE
feat(TextSegment): add WriteTo appendLine override, inline storage, and Count

### DIFF
--- a/src/InterpolationCodeWriter/Internals/Throws.cs
+++ b/src/InterpolationCodeWriter/Internals/Throws.cs
@@ -40,6 +40,32 @@ internal static class Throws
     }
 
     /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException"/> if the specified index is outside the valid range.
+    /// </summary>
+    /// <param name="index">The index to validate.</param>
+    /// <param name="length">The exclusive upper bound; the index must be less than this value.</param>
+    /// <param name="paramName">The name of the parameter being checked.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="index"/> is negative or greater than or equal to <paramref name="length"/>.
+    /// </exception>
+    public static void IndexOutOfRangeIfInvalid(int index, int length, string paramName)
+    {
+        if (index >= length)
+        {
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                index,
+                $"The index must be less than {length}. Actual: {index}"
+            );
+        }
+
+        if (index < 0)
+        {
+            throw new ArgumentOutOfRangeException(paramName, index, $"The index must be non-negative. Actual: {index}");
+        }
+    }
+
+    /// <summary>
     /// Throws an <see cref="InvalidOperationException"/> if the specified condition is true.
     /// </summary>
     /// <param name="condition">The condition to evaluate.</param>
@@ -60,7 +86,10 @@ internal static class Throws
     public static void MinMaxExceptionIf(uint min, uint max)
     {
         if (min > max)
-            throw new ArgumentOutOfRangeException(nameof(min), $"Minimum value cannot be greater than maximum. min: {min}, max: {max}");
+            throw new ArgumentOutOfRangeException(
+                nameof(min),
+                $"Minimum value cannot be greater than maximum. min: {min}, max: {max}"
+            );
     }
 
     /// <summary>

--- a/src/InterpolationCodeWriter/TextSegment.Collection.cs
+++ b/src/InterpolationCodeWriter/TextSegment.Collection.cs
@@ -1,0 +1,116 @@
+﻿#nullable enable
+
+using System;
+using System.Runtime.CompilerServices;
+using Raiqub.Generators.InterpolationCodeWriter.Internals;
+
+namespace Raiqub.Generators.InterpolationCodeWriter;
+
+partial struct TextSegment
+{
+    /// <summary>Gets the string part at the specified index.</summary>
+    /// <param name="index">The zero-based index of the part to get.</param>
+    /// <returns>The string part at <paramref name="index"/>, or <see langword="null"/> if that part was a null value.</returns>
+    /// <exception cref="IndexOutOfRangeException"><paramref name="index"/> is less than zero or greater than or equal to the number of parts.</exception>
+    public string? this[int index]
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get
+        {
+            Throws.IndexOutOfRangeIfInvalid(index, _length, nameof(index));
+            return GetItemAt(index);
+        }
+        private set
+        {
+            Throws.IndexOutOfRangeIfInvalid(index, _length, nameof(index));
+            switch (index)
+            {
+                case 0:
+                    _part0 = value;
+                    break;
+                case 1:
+                    _part1 = value;
+                    break;
+                case 2:
+                    _part2 = value;
+                    break;
+                case 3:
+                    _part3 = value;
+                    break;
+                case 4:
+                    _part4 = value;
+                    break;
+                case 5:
+                    _part5 = value;
+                    break;
+                case 6:
+                    _part6 = value;
+                    break;
+                case 7:
+                    _part7 = value;
+                    break;
+                default:
+                    _additionalParts![index - MinimumCapacity] = value;
+                    break;
+            }
+        }
+    }
+
+    private readonly int Capacity
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _additionalParts?.Length + MinimumCapacity ?? MinimumCapacity;
+    }
+
+    /// <summary>Returns an enumerator that iterates through the string parts of this segment.</summary>
+    /// <returns>An <see cref="Enumerator"/> for this <see cref="TextSegment"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly Enumerator GetEnumerator() => new(this);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private readonly string? GetItemAt(int index) =>
+        index switch
+        {
+            0 => _part0,
+            1 => _part1,
+            2 => _part2,
+            3 => _part3,
+            4 => _part4,
+            5 => _part5,
+            6 => _part6,
+            7 => _part7,
+            _ => _additionalParts![index - MinimumCapacity],
+        };
+
+    /// <summary>Enumerates the string parts of a <see cref="TextSegment"/>.</summary>
+    public ref struct Enumerator
+    {
+        private readonly TextSegment _segment;
+        private int _position;
+
+        /// <summary>Initializes a new instance of <see cref="Enumerator"/> for the specified segment.</summary>
+        /// <param name="segment">The <see cref="TextSegment"/> to enumerate.</param>
+        public Enumerator(TextSegment segment)
+        {
+            _segment = segment;
+            _position = -1;
+        }
+
+        /// <summary>Advances the enumerator to the next part.</summary>
+        /// <returns><see langword="true"/> if the enumerator was successfully advanced; <see langword="false"/> if the enumerator has passed the end of the segment.</returns>
+        public bool MoveNext()
+        {
+            if (_position >= _segment._length - 1)
+            {
+                return false;
+            }
+
+            _position++;
+            return true;
+        }
+
+        /// <summary>Gets the string part at the current position of the enumerator.</summary>
+        /// <value>The string part at the current position, or <see langword="null"/> if that part was a null value.</value>
+        public readonly string? Current => _segment.GetItemAt(_position);
+    }
+}

--- a/src/InterpolationCodeWriter/TextSegment.Collection.cs
+++ b/src/InterpolationCodeWriter/TextSegment.Collection.cs
@@ -56,6 +56,9 @@ partial struct TextSegment
         }
     }
 
+    /// <summary>Gets the number of string parts in this segment.</summary>
+    public readonly int Count => _length;
+
     private readonly int Capacity
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/InterpolationCodeWriter/TextSegment.Interpolation.cs
+++ b/src/InterpolationCodeWriter/TextSegment.Interpolation.cs
@@ -34,7 +34,15 @@ partial struct TextSegment
         _appendLine = false;
 
         var capacity = formattedCount * 2 + 1;
-        _parts = new Item[capacity];
+        _part0 = null;
+        _part1 = null;
+        _part2 = null;
+        _part3 = null;
+        _part4 = null;
+        _part5 = null;
+        _part6 = null;
+        _part7 = null;
+        _additionalParts = capacity > MinimumCapacity ? new string?[capacity - MinimumCapacity] : null;
     }
 
     /// <summary>Appends a literal string part to the segment.</summary>
@@ -42,7 +50,7 @@ partial struct TextSegment
     public void AppendLiteral(string s)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = s;
+        this[_length++] = s;
     }
 
     #region Generic formatting
@@ -66,7 +74,7 @@ partial struct TextSegment
     {
         EnsureCapacityForAdditionalItems(1);
         var str = value is IFormattable formattable ? formattable.ToString(format, _provider) : value?.ToString();
-        _parts[_length++] = str;
+        this[_length++] = str;
     }
 
     /// <summary>Appends the string representation of a <see cref="bool"/> value to the segment.</summary>
@@ -74,7 +82,7 @@ partial struct TextSegment
     public void AppendFormatted(bool value)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value.ToString(_provider);
+        this[_length++] = value.ToString(_provider);
     }
 
     #endregion
@@ -86,7 +94,7 @@ partial struct TextSegment
     public void AppendFormatted(char value)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value.ToString(_provider);
+        this[_length++] = value.ToString(_provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="byte"/> value to the segment.</summary>
@@ -102,7 +110,7 @@ partial struct TextSegment
     public void AppendFormatted(byte value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value.ToString(format, _provider);
+        this[_length++] = value.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of an <see cref="sbyte"/> value to the segment.</summary>
@@ -118,7 +126,7 @@ partial struct TextSegment
     public void AppendFormatted(sbyte value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value.ToString(format, _provider);
+        this[_length++] = value.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="short"/> value to the segment.</summary>
@@ -134,7 +142,7 @@ partial struct TextSegment
     public void AppendFormatted(short value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value.ToString(format, _provider);
+        this[_length++] = value.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="ushort"/> value to the segment.</summary>
@@ -150,7 +158,7 @@ partial struct TextSegment
     public void AppendFormatted(ushort value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value.ToString(format, _provider);
+        this[_length++] = value.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of an <see cref="int"/> value to the segment.</summary>
@@ -166,7 +174,7 @@ partial struct TextSegment
     public void AppendFormatted(int value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value.ToString(format, _provider);
+        this[_length++] = value.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="uint"/> value to the segment.</summary>
@@ -182,7 +190,7 @@ partial struct TextSegment
     public void AppendFormatted(uint value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value.ToString(format, _provider);
+        this[_length++] = value.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="long"/> value to the segment.</summary>
@@ -198,7 +206,7 @@ partial struct TextSegment
     public void AppendFormatted(long value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value.ToString(format, _provider);
+        this[_length++] = value.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="ulong"/> value to the segment.</summary>
@@ -214,7 +222,7 @@ partial struct TextSegment
     public void AppendFormatted(ulong value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value.ToString(format, _provider);
+        this[_length++] = value.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="float"/> value to the segment.</summary>
@@ -230,7 +238,7 @@ partial struct TextSegment
     public void AppendFormatted(float value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value.ToString(format, _provider);
+        this[_length++] = value.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="double"/> value to the segment.</summary>
@@ -246,7 +254,7 @@ partial struct TextSegment
     public void AppendFormatted(double value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value.ToString(format, _provider);
+        this[_length++] = value.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="decimal"/> value to the segment.</summary>
@@ -262,7 +270,7 @@ partial struct TextSegment
     public void AppendFormatted(decimal value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value.ToString(format, _provider);
+        this[_length++] = value.ToString(format, _provider);
     }
 
     #endregion
@@ -274,7 +282,7 @@ partial struct TextSegment
     public void AppendFormatted(bool? value)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value?.ToString(_provider);
+        this[_length++] = value?.ToString(_provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="char"/> value to the segment, or nothing if the value is <see langword="null"/>.</summary>
@@ -282,7 +290,7 @@ partial struct TextSegment
     public void AppendFormatted(char? value)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value?.ToString(_provider);
+        this[_length++] = value?.ToString(_provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="byte"/> value to the segment, or nothing if the value is <see langword="null"/>.</summary>
@@ -298,7 +306,7 @@ partial struct TextSegment
     public void AppendFormatted(byte? value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value?.ToString(format, _provider);
+        this[_length++] = value?.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of an <see cref="sbyte"/> value to the segment, or nothing if the value is <see langword="null"/>.</summary>
@@ -314,7 +322,7 @@ partial struct TextSegment
     public void AppendFormatted(sbyte? value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value?.ToString(format, _provider);
+        this[_length++] = value?.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="short"/> value to the segment, or nothing if the value is <see langword="null"/>.</summary>
@@ -330,7 +338,7 @@ partial struct TextSegment
     public void AppendFormatted(short? value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value?.ToString(format, _provider);
+        this[_length++] = value?.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="ushort"/> value to the segment, or nothing if the value is <see langword="null"/>.</summary>
@@ -346,7 +354,7 @@ partial struct TextSegment
     public void AppendFormatted(ushort? value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value?.ToString(format, _provider);
+        this[_length++] = value?.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of an <see cref="int"/> value to the segment, or nothing if the value is <see langword="null"/>.</summary>
@@ -362,7 +370,7 @@ partial struct TextSegment
     public void AppendFormatted(int? value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value?.ToString(format, _provider);
+        this[_length++] = value?.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="uint"/> value to the segment, or nothing if the value is <see langword="null"/>.</summary>
@@ -378,7 +386,7 @@ partial struct TextSegment
     public void AppendFormatted(uint? value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value?.ToString(format, _provider);
+        this[_length++] = value?.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="long"/> value to the segment, or nothing if the value is <see langword="null"/>.</summary>
@@ -394,7 +402,7 @@ partial struct TextSegment
     public void AppendFormatted(long? value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value?.ToString(format, _provider);
+        this[_length++] = value?.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="ulong"/> value to the segment, or nothing if the value is <see langword="null"/>.</summary>
@@ -410,7 +418,7 @@ partial struct TextSegment
     public void AppendFormatted(ulong? value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value?.ToString(format, _provider);
+        this[_length++] = value?.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="float"/> value to the segment, or nothing if the value is <see langword="null"/>.</summary>
@@ -426,7 +434,7 @@ partial struct TextSegment
     public void AppendFormatted(float? value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value?.ToString(format, _provider);
+        this[_length++] = value?.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="double"/> value to the segment, or nothing if the value is <see langword="null"/>.</summary>
@@ -442,7 +450,7 @@ partial struct TextSegment
     public void AppendFormatted(double? value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value?.ToString(format, _provider);
+        this[_length++] = value?.ToString(format, _provider);
     }
 
     /// <summary>Appends the string representation of a <see cref="decimal"/> value to the segment, or nothing if the value is <see langword="null"/>.</summary>
@@ -458,7 +466,7 @@ partial struct TextSegment
     public void AppendFormatted(decimal? value, string? format)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value?.ToString(format, _provider);
+        this[_length++] = value?.ToString(format, _provider);
     }
 
     #endregion
@@ -470,7 +478,7 @@ partial struct TextSegment
     public void AppendFormatted(string? value)
     {
         EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value;
+        this[_length++] = value;
     }
 
     #endregion
@@ -492,22 +500,30 @@ partial struct TextSegment
     {
         EnsureCapacityForAdditionalItems(1);
         var str = value is IFormattable formattable ? formattable.ToString(format, _provider) : value?.ToString();
-        _parts[_length++] = str;
+        this[_length++] = str;
     }
 
     /// <summary>Appends a <see cref="TextSegment"/> as a nested part of this segment.</summary>
     /// <param name="value">The segment to append.</param>
     public void AppendFormatted(in TextSegment value)
     {
-        EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value;
+        EnsureCapacityForAdditionalItems(value._length);
+        foreach (var item in value)
+        {
+            this[_length++] = item;
+        }
     }
 
     /// <summary>Appends a <see cref="TextSegment"/> as a nested part of this sequence, or nothing if the value is <see langword="null"/>.</summary>
     /// <param name="value">The segment to append.</param>
     public void AppendFormatted(in TextSegment? value)
     {
-        EnsureCapacityForAdditionalItems(1);
-        _parts[_length++] = value;
+        if (value is null)
+        {
+            return;
+        }
+
+        var underlyingValue = value.Value;
+        AppendFormatted(in underlyingValue);
     }
 }

--- a/src/InterpolationCodeWriter/TextSegment.cs
+++ b/src/InterpolationCodeWriter/TextSegment.cs
@@ -108,8 +108,7 @@ public partial struct TextSegment
     /// <returns>A new <see cref="TextSegment"/> built from the interpolated string.</returns>
     public static ref TextSegment Create(
         IFormatProvider? provider,
-        [InterpolatedStringHandlerArgument("provider")]
-        ref TextSegment handler,
+        [InterpolatedStringHandlerArgument("provider")] ref TextSegment handler,
         bool appendLine = false
     )
     {
@@ -137,12 +136,26 @@ public partial struct TextSegment
     /// <param name="writer">The writer to which the parts are written.</param>
     public readonly void WriteTo(SourceTextWriter writer)
     {
+        WriteTo(writer, _appendLine);
+    }
+
+    /// <summary>
+    /// Writes all parts of this segment to the specified <see cref="SourceTextWriter"/>,
+    /// overriding whether a line terminator is appended.
+    /// </summary>
+    /// <param name="writer">The writer to which the parts are written.</param>
+    /// <param name="appendLine">
+    /// <see langword="true"/> to append a line terminator after writing all parts;
+    /// <see langword="false"/> otherwise. Overrides <see cref="AppendLine"/>.
+    /// </param>
+    public readonly void WriteTo(SourceTextWriter writer, bool appendLine)
+    {
         foreach (var item in _parts.AsSpan(0, _length))
         {
             item.WriteTo(writer);
         }
 
-        if (_appendLine)
+        if (appendLine)
         {
             writer.WriteLine();
         }

--- a/src/InterpolationCodeWriter/TextSegment.cs
+++ b/src/InterpolationCodeWriter/TextSegment.cs
@@ -33,15 +33,33 @@ namespace Raiqub.Generators.InterpolationCodeWriter;
 [DebuggerDisplay("{DebuggerDisplay}")]
 public partial struct TextSegment
 {
+    private const int MinimumCapacity = 8;
+
     private readonly IFormatProvider _provider;
-    private Item[] _parts;
+    private string? _part0;
+    private string? _part1;
+    private string? _part2;
+    private string? _part3;
+    private string? _part4;
+    private string? _part5;
+    private string? _part6;
+    private string? _part7;
+    private string?[]? _additionalParts;
     private bool _appendLine;
     private int _length;
 
     private TextSegment(string? value)
     {
         _provider = CultureInfo.InvariantCulture;
-        _parts = new Item[] { value };
+        _part0 = value;
+        _part1 = null;
+        _part2 = null;
+        _part3 = null;
+        _part4 = null;
+        _part5 = null;
+        _part6 = null;
+        _part7 = null;
+        _additionalParts = null;
         _appendLine = false;
         _length = 1;
     }
@@ -63,9 +81,9 @@ public partial struct TextSegment
         get
         {
             var sb = new StringBuilder();
-            foreach (var item in _parts.AsSpan(0, _length))
+            foreach (var item in this)
             {
-                sb.Append(item.ToString());
+                sb.Append(item);
             }
 
             if (_appendLine)
@@ -125,8 +143,18 @@ public partial struct TextSegment
     /// </returns>
     public readonly IReadOnlyList<string?> ToList()
     {
-        var list = new List<string?>();
-        FillList(list);
+        var list = new string?[_length];
+        var inlineCount = Math.Min(_length, MinimumCapacity);
+        for (var i = 0; i < inlineCount; i++)
+        {
+            list[i] = GetItemAt(i);
+        }
+
+        if (_additionalParts?.Length > 0)
+        {
+            Array.Copy(_additionalParts, 0, list, MinimumCapacity, _length - MinimumCapacity);
+        }
+
         return list;
     }
 
@@ -150,9 +178,9 @@ public partial struct TextSegment
     /// </param>
     public readonly void WriteTo(SourceTextWriter writer, bool appendLine)
     {
-        foreach (var item in _parts.AsSpan(0, _length))
+        foreach (var item in this)
         {
-            item.WriteTo(writer);
+            writer.Write(item);
         }
 
         if (appendLine)
@@ -164,76 +192,21 @@ public partial struct TextSegment
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void EnsureCapacityForAdditionalItems(int additionalItems)
     {
-        if (_parts.Length - _length < additionalItems)
+        if (Capacity - _length < additionalItems)
         {
             Grow(additionalItems);
         }
     }
 
-    private readonly void FillList(List<string?> list)
-    {
-        foreach (var item in _parts.AsSpan(0, _length))
-        {
-            item.FillList(list);
-        }
-    }
-
     private void Grow(int additionalItems)
     {
-        var requiredMinCapacity = (uint)_length + (uint)additionalItems;
-        var newCapacity = Math.Max(requiredMinCapacity, Math.Min((uint)_parts.Length * 2, int.MaxValue));
+        var requiredMinCapacity = (uint)_length + (uint)additionalItems - MinimumCapacity;
+        var newCapacity = Math.Max(
+            requiredMinCapacity,
+            Math.Min((uint)(_additionalParts?.Length ?? 0) * 2, int.MaxValue)
+        );
         var arraySize = (int)MathEx.Clamp(newCapacity, 4, int.MaxValue);
 
-        Array.Resize(ref _parts, arraySize);
-    }
-
-    private readonly struct Item
-    {
-        private readonly string? _text;
-        private readonly TextSegment? _textSequence;
-
-        private Item(string? text)
-        {
-            _text = text;
-            _textSequence = null;
-        }
-
-        private Item(TextSegment? textSequence)
-        {
-            _textSequence = textSequence;
-            _text = null;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static implicit operator Item(string? value) => new(value);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static implicit operator Item(in TextSegment? value) => new(value);
-
-        public void WriteTo(SourceTextWriter writer)
-        {
-            if (_textSequence.HasValue)
-            {
-                _textSequence.Value.WriteTo(writer);
-            }
-            else
-            {
-                writer.Write(_text);
-            }
-        }
-
-        public void FillList(List<string?> list)
-        {
-            if (_textSequence.HasValue)
-            {
-                _textSequence.Value.FillList(list);
-            }
-            else
-            {
-                list.Add(_text);
-            }
-        }
-
-        public override string? ToString() => _textSequence.HasValue ? _textSequence.Value.DebuggerDisplay : _text;
+        Array.Resize(ref _additionalParts, arraySize);
     }
 }

--- a/tests/InterpolationCodeWriter.Tests/TextSegmentTest.Collection.cs
+++ b/tests/InterpolationCodeWriter.Tests/TextSegmentTest.Collection.cs
@@ -1,0 +1,130 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Raiqub.Generators.InterpolationCodeWriter.Tests;
+
+public class TextSegmentCollectionTest
+{
+    // $"a{1}b{2}c{3}d{4}e" → 9 parts:
+    // index 0-7 in inline fields (_part0…_part7), index 8 in _additionalParts[0]
+    private static TextSegment NinePartSegment =>
+        $"a{1}b{2}c{3}d{4}e";
+
+    #region Indexer
+
+    [Theory]
+    [InlineData(0, "a")]   // first inline literal
+    [InlineData(1, "1")]   // first formatted value
+    [InlineData(6, "d")]   // seventh inline part (literal)
+    [InlineData(7, "4")]   // last inline part (formatted value)
+    public void IndexerReturnsInlinePart(int index, string expected)
+    {
+        Assert.Equal(expected, NinePartSegment[index]);
+    }
+
+    [Fact]
+    public void IndexerReturnsAdditionalPart()
+    {
+        // index 8 lives in _additionalParts[0], past the 8 inline fields
+        Assert.Equal("e", NinePartSegment[8]);
+    }
+
+    [Fact]
+    [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider")]
+    public void IndexerReturnsNullForNullFormattedValue()
+    {
+        TextSegment seg = $"x{(string?)null}y";
+        Assert.Null(seg[1]);
+    }
+
+    [Fact]
+    public void IndexerThrowsForNegativeIndex()
+    {
+        TextSegment seg = $"hello";
+        Assert.Throws<ArgumentOutOfRangeException>(() => seg[-1]);
+    }
+
+    [Fact]
+    public void IndexerThrowsForIndexEqualToLength()
+    {
+        TextSegment seg = $"hello";
+        // length == 1 (single literal); index 1 is out of range
+        Assert.Throws<ArgumentOutOfRangeException>(() => seg[1]);
+    }
+
+    [Fact]
+    public void IndexerThrowsForIndexGreaterThanLength()
+    {
+        TextSegment seg = $"hello";
+        Assert.Throws<ArgumentOutOfRangeException>(() => seg[99]);
+    }
+
+    #endregion
+
+    #region Enumerator
+
+    [Fact]
+    [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider")]
+    public void EnumeratorIteratesAllEightInlineParts()
+    {
+        // 8 parts exactly fill the inline fields; no _additionalParts needed
+        TextSegment seg = $"a{1}b{2}c{3}d{4}";
+        var result = new List<string?>();
+        foreach (var part in seg)
+        {
+            result.Add(part);
+        }
+
+        Assert.Equal(["a", "1", "b", "2", "c", "3", "d", "4"], result);
+    }
+
+    [Fact]
+    public void EnumeratorIteratesPartsAcrossInlineAndAdditional()
+    {
+        // 9 parts: 8 inline + 1 in _additionalParts
+        var result = new List<string?>();
+        foreach (var part in NinePartSegment)
+        {
+            result.Add(part);
+        }
+
+        Assert.Equal(["a", "1", "b", "2", "c", "3", "d", "4", "e"], result);
+    }
+
+    [Fact]
+    [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider")]
+    public void EnumeratorYieldsNullForNullFormattedValues()
+    {
+        TextSegment seg = $"x{(int?)null}y";
+        var result = new List<string?>();
+        foreach (var part in seg)
+        {
+            result.Add(part);
+        }
+
+        Assert.Equal(["x", null, "y"], result);
+    }
+
+    [Fact]
+    public void EnumeratorMoveNextReturnsFalseAfterLastPart()
+    {
+        TextSegment seg = $"hello";
+        var enumerator = seg.GetEnumerator();
+        Assert.True(enumerator.MoveNext());   // advances to part 0
+        Assert.Equal("hello", enumerator.Current);
+        Assert.False(enumerator.MoveNext());  // no more parts
+    }
+
+    [Fact]
+    public void EnumeratorEachCallIsIndependent()
+    {
+        // Two independent enumerations of the same segment should yield equal results
+        var first = new List<string?>();
+        var second = new List<string?>();
+        foreach (var part in NinePartSegment) first.Add(part);
+        foreach (var part in NinePartSegment) second.Add(part);
+
+        Assert.Equal(first, second);
+    }
+
+    #endregion
+}

--- a/tests/InterpolationCodeWriter.Tests/TextSegmentTest.Collection.cs
+++ b/tests/InterpolationCodeWriter.Tests/TextSegmentTest.Collection.cs
@@ -9,6 +9,31 @@ public class TextSegmentCollectionTest
     private static TextSegment NinePartSegment =>
         $"a{1}b{2}c{3}d{4}e";
 
+    #region Count
+
+    [Fact]
+    public void CountReturnsNumberOfParts()
+    {
+        Assert.Equal(9, NinePartSegment.Count);
+    }
+
+    [Fact]
+    [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider")]
+    public void CountReturnsEightForFullyInlineSegment()
+    {
+        TextSegment seg = $"a{1}b{2}c{3}d{4}";
+        Assert.Equal(8, seg.Count);
+    }
+
+    [Fact]
+    public void CountReturnsOneForSingleLiteral()
+    {
+        TextSegment seg = $"hello";
+        Assert.Equal(1, seg.Count);
+    }
+
+    #endregion
+
     #region Indexer
 
     [Theory]

--- a/tests/InterpolationCodeWriter.Tests/TextSegmentTest.cs
+++ b/tests/InterpolationCodeWriter.Tests/TextSegmentTest.cs
@@ -132,6 +132,11 @@ public class TextSegmentTest
                 $"[{(TextSegment?)TextSegment.Create($"inner")}]",
                 new List<string?> { "[", "inner", "]" }
             },
+            // More than 8 segments: formattedCount=4 → capacity=4*2+1=9 > MinimumCapacity
+            {
+                $"a{1}b{2}c{3}d{4}e",
+                new List<string?> { "a", "1", "b", "2", "c", "3", "d", "4", "e" }
+            },
         };
 
     [Theory]
@@ -179,49 +184,54 @@ public class TextSegmentTest
     [Fact]
     public void GrowFromMinimumCapacityPreservesAllParts()
     {
-        // capacity starts at 1 (formattedCount=0 → 0*2+1=1)
-        // second AppendLiteral triggers Grow: requiredMinCapacity=2, clamped to minimum 4
-        var seg = new TextSegment(0, 0);
-        seg.AppendLiteral("a");
-        seg.AppendLiteral("b");
-
-        var writer = new SourceTextWriter();
-        seg.WriteTo(writer);
-
-        Assert.Equal("ab", writer.ToStringAndReset());
-    }
-
-    [Fact]
-    public void GrowDoublesCapacityWhenDoubleSuffices()
-    {
-        // Fill to capacity 4 (after first grow), then trigger a second grow to 8
-        var seg = new TextSegment(0, 0);
-        seg.AppendLiteral("1");
-        seg.AppendLiteral("2"); // grow 1→4
-        seg.AppendLiteral("3");
-        seg.AppendLiteral("4");
-        seg.AppendLiteral("5"); // grow 4→8
-
-        var writer = new SourceTextWriter();
-        seg.WriteTo(writer);
-
-        Assert.Equal("12345", writer.ToStringAndReset());
-    }
-
-    [Fact]
-    public void GrowMultipleTimesPreservesAllPartsInOrder()
-    {
-        // 1→4→8→16: verifies each resize keeps all prior elements intact
+        // inline capacity = 8; 9th AppendLiteral triggers first Grow:
+        // _additionalParts allocated with size 4 (capacity 8→12)
         var seg = new TextSegment(0, 0);
         for (int i = 1; i <= 9; i++)
         {
-            seg.AppendLiteral(i.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            seg.AppendLiteral(i.ToString(CultureInfo.InvariantCulture));
         }
 
         var writer = new SourceTextWriter();
         seg.WriteTo(writer);
 
         Assert.Equal("123456789", writer.ToStringAndReset());
+    }
+
+    [Fact]
+    public void GrowDoublesCapacityWhenDoubleSuffices()
+    {
+        // 9th item triggers first Grow: _additionalParts 0→4 (capacity 8→12)
+        // 13th item triggers second Grow: double suffices, _additionalParts 4→8 (capacity 12→16)
+        var seg = new TextSegment(0, 0);
+        for (int i = 1; i <= 13; i++)
+        {
+            seg.AppendLiteral(i.ToString(CultureInfo.InvariantCulture));
+        }
+
+        var writer = new SourceTextWriter();
+        seg.WriteTo(writer);
+
+        Assert.Equal("12345678910111213", writer.ToStringAndReset());
+    }
+
+    [Fact]
+    public void GrowMultipleTimesPreservesAllPartsInOrder()
+    {
+        // 9th item:  Grow 1 — _additionalParts 0→4  (capacity 8→12)
+        // 13th item: Grow 2 — _additionalParts 4→8  (capacity 12→16)
+        // 17th item: Grow 3 — _additionalParts 8→16 (capacity 16→24)
+        // verifies each resize keeps all prior elements intact
+        var seg = new TextSegment(0, 0);
+        for (int i = 1; i <= 17; i++)
+        {
+            seg.AppendLiteral(i.ToString(CultureInfo.InvariantCulture));
+        }
+
+        var writer = new SourceTextWriter();
+        seg.WriteTo(writer);
+
+        Assert.Equal("1234567891011121314151617", writer.ToStringAndReset());
     }
 
     [Fact]

--- a/tests/InterpolationCodeWriter.Tests/TextSegmentTest.cs
+++ b/tests/InterpolationCodeWriter.Tests/TextSegmentTest.cs
@@ -153,6 +153,29 @@ public class TextSegmentTest
             { TextSegment.Create($"value={42}", appendLine: true), "value=42" + Environment.NewLine },
         };
 
+    [Theory]
+    [MemberData(nameof(WriteToWithAppendLineOverrideCases))]
+    public void WriteToOverrideAppendLineWritesCorrectly(TextSegment seq, bool appendLine, string expected)
+    {
+        var writer = new SourceTextWriter();
+        seq.WriteTo(writer, appendLine);
+        Assert.Equal(expected, writer.ToStringAndReset());
+    }
+
+    [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider")]
+    public static TheoryData<TextSegment, bool, string> WriteToWithAppendLineOverrideCases =>
+        new()
+        {
+            // Override false → suppresses the stored appendLine=true
+            { TextSegment.Create($"hello", appendLine: true), false, "hello" },
+            // Override true → appends line even though stored appendLine=false
+            { TextSegment.Create($"hello", appendLine: false), true, "hello\n" },
+            // No-op override: matches stored value (false)
+            { TextSegment.Create($"hello"), false, "hello" },
+            // No-op override: matches stored value (true)
+            { TextSegment.Create($"hello", appendLine: true), true, "hello\n" },
+        };
+
     [Fact]
     public void GrowFromMinimumCapacityPreservesAllParts()
     {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "2.3",
+    "version": "2.4",
     "pathFilters": ["src"],
     "publicReleaseRefSpec": [
         "^refs/tags/v\\d+\\.\\d+"


### PR DESCRIPTION
## Summary

- Adds `WriteTo(SourceTextWriter, bool appendLine)` overload to override the segment's stored `AppendLine` flag at write time
- Replaces the internal dynamic array with 8 inline `string?` fields (`_part0`–`_part7`) plus an overflow array, eliminating heap allocation for segments with ≤ 8 parts
- Adds `TextSegment.Collection` partial exposing `Count`, a public indexer, and `GetEnumerator` over the inline storage
- Adds `Throws.IndexOutOfRangeIfInvalid` helper for bounds checking in the new indexer
- Adds `TextSegmentTest.Collection` tests covering `Count`, the indexer, and enumeration behaviors

## Test plan

- [x] Run `dotnet test` — all existing and new tests pass
- [x] Verify zero-alloc fast path: segments with ≤ 8 parts produce no `_additionalParts` allocation
- [x] Verify fallback path: segments with > 8 parts still work correctly via the overflow array

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by CodeRabbit
- New Features

  - TextSegment now supports collection-like operations: direct indexing to access individual elements, enumeration with foreach loops, and a Count property for segment size
  - Improved boundary validation with clearer error messages when accessing elements out of bounds

- Chores

  - Version updated to 2.4