### PR TITLE
fix(TextSegment): Set struct layout for TextSegment enumerator struct

### DIFF
--- a/src/InterpolationCodeWriter/TextSegment.Collection.cs
+++ b/src/InterpolationCodeWriter/TextSegment.Collection.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Raiqub.Generators.InterpolationCodeWriter.Internals;
 
 namespace Raiqub.Generators.InterpolationCodeWriter;
@@ -86,6 +87,7 @@ partial struct TextSegment
         };
 
     /// <summary>Enumerates the string parts of a <see cref="TextSegment"/>.</summary>
+    [StructLayout(LayoutKind.Auto)]
     public ref struct Enumerator
     {
         private readonly TextSegment _segment;


### PR DESCRIPTION
Resolves MA0008: `StructLayoutAttribute` is required on all structs by the Meziantou analyzer.

`LayoutKind.Auto` is used rather than `Sequential` because `Enumerator` is a `ref struct` — it cannot be marshaled to unmanaged code, so there is no reason to impose a fixed memory layout. `Auto` lets the runtime order fields for optimal padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied internal performance optimization to core collection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->